### PR TITLE
Fix K10.DTB.Tree typespec

### DIFF
--- a/lib/k10/dtb.ex
+++ b/lib/k10/dtb.ex
@@ -46,7 +46,7 @@ defmodule K10.DTB do
     @type t :: %Tree{
             header: Header.t(),
             strings: binary,
-            structs: map
+            structs: list
           }
     defstruct [:header, :strings, :structs]
   end


### PR DESCRIPTION
Structs are now lists and not maps since #3 